### PR TITLE
Fixed bug in ClassPlotter.m

### DIFF
--- a/ClassPlotter.m
+++ b/ClassPlotter.m
@@ -234,7 +234,7 @@ classdef ClassPlotter < handle
                         subplot(2,1,2);
                         plotLower = lineGroup.Plot(settingsLowerPlot);
 %                         set(plotLower,'Position',settingsLowerPlot.BoxPosition);
-                    else
+                    elseif exist('plotLower','var')
                         delete(plotLower);
                     end
                     

--- a/THistPlot.m
+++ b/THistPlot.m
@@ -24,7 +24,7 @@ function THistPlot(varargin)
 %
     clc;
 
-    version = '1.0.0-beta.3';
+    version = '1.0.0-beta.4';
     scriptPathFull = mfilename('fullpath');
     [scriptPath,~] = fileparts(scriptPathFull);
     fullfile(scriptPath,'/usr/lib')


### PR DESCRIPTION
Error at line 238 in ClassPlotter.m if trying to delete the lowerPlot. Only occurs if the first plotgroup has only one curve.

